### PR TITLE
Dependency updates March 2023

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: '>=2.11.0 <3.0.0'
 
 dev_dependencies:
-  dart_dev: ^3.9.0
+  dart_dev: ^3.9.2
   dart_dev_workiva:
     hosted:
       name: dart_dev_workiva
       url: https://pub.workiva.org
-    version: ^2.0.1
+    version: ^2.0.4
   dart_style: ^1.3.14
-  dependency_validator: ^2.0.3
+  dependency_validator: ^3.0.0
   test: ^1.16.5
   workiva_analysis_options: ^1.3.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades
(This is part of Milestone 12)

  # partially unblocks analyzer 2
  pubspec_codemod raise-min dependency_validator 3.0.0 --recursive
  
  # We already resolve to built_redux 8, step 2 raise minimum
  pubspec_codemod raise-min built_redux 8.0.0 --recursive
  
  # Allow the nullsafe version of intl
  pubspec_codemod raise-min intl 0.17.0 --recursive
  pubspec_codemod raise-max intl 0.19.0 --recursive
  pubspec_codemod raise-max color 4.0.0 --recursive
  
  # Shorten pub get times
  pubspec_codemod raise-min dart_dev 3.9.2 --recursive
  pubspec_codemod raise-min dart_dev_workiva 2.0.4 --recursive

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_dep_updates_mar23`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_dep_updates_mar23)