### PR TITLE
Test Dart 2.18.7 base image created via GHA

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,7 +1,7 @@
 name: standard-dart-checks
 description: Quality checks (analyze, format, dependency validator)
 contact: 'Frontend Architecture / #support-frontend-architecture'
-image: drydock.workiva.net/workiva/dart2_base_image:1
+image: drydock.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7gha
 size: large
 timeout: eternal
 
@@ -18,7 +18,7 @@ name: semver-audit
 description: Runs the semver-audit tool to check for minor and major changes
 contact: 'Frontend Architecture / #support-frontend-architecture'
 
-image: drydock.workiva.net/workiva/dart2_base_image:1
+image: drydock.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7gha
 size: small
 timeout: 300
 


### PR DESCRIPTION
NO MERGE : Testing Dart 2.18.7 dart2_base_image GHA
---

This is a test PR to run CI with the base image created via github actions
instead of Workiva Build.

For more info, visit `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/test_dart_218_gha`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_dart_218_gha)