### PR TITLE
Fix standard-dart-checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
     tags:
       - '**'
 
+permissions:
+  contents: write
+  
 jobs:
   standard-dart-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
standard-dart-checks requires write permission for sbom-action to function properly

https://github.com/Workiva/contextual_message/actions/runs/10147699565/job/28058716367