### PR TITLE
Update dependencies to allow analyzer 10

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  build_test: ^2.0.0
+  build_test: '>=2.0.0 <4.0.0'
   dart_dev: ^4.0.0
-  dart_style: ^2.0.0
-  dependency_validator: ^3.0.0
+  dart_style: '>=2.0.0 <4.0.0'
+  dependency_validator: '>=3.0.0 <6.0.0'
   test: ^1.16.5
   workiva_analysis_options: ^1.3.0


### PR DESCRIPTION
This pull request updates the version constraints for several development dependencies in the `pubspec.yaml` file to allow for compatibility with newer versions while maintaining upper bounds.

Dependency version updates:

* Relaxed the version constraints for `build_test`, `dart_style`, and `dependency_validator` to allow versions up to, but not including, their respective next major versions (`build_test: '>=2.0.0 <4.0.0'`, `dart_style: '>=2.0.0 <4.0.0'`, `dependency_validator: '>=3.0.0 <6.0.0'`).